### PR TITLE
Update RLW_arrange_channels.m

### DIFF
--- a/RLW/RLW_arrange_channels.m
+++ b/RLW/RLW_arrange_channels.m
@@ -1,11 +1,11 @@
-function [out_header,out_data,message_string]=RLW_arrange_channels(header,data,channel_idx);
+function [out_header,out_data,message_string]=RLW_arrange_channels(header,data,channel_lbl)
 %RLW_arrange_channels
 %
 %Arrange or delete channels
 %
 %header
 %data
-%channel_idx
+%channel_lbl
 %
 % Author : 
 % Andre Mouraux
@@ -22,10 +22,16 @@ function [out_header,out_data,message_string]=RLW_arrange_channels(header,data,c
 %init message_string
 message_string={};
 message_string{1}='Arrange or delete channels';
-message_string{end+1}=['Number of channels : ' num2str(length(channel_idx))];
+message_string{end+1}=['Number of channels : ' num2str(length(channel_lbl))];
 
 %prepare out_header
 out_header=header;
+
+%find the indexes related to the channels to be selected
+channel_idx = [];
+for klbl = 1:length(channel_lbl)
+    channel_idx = [channel_idx, find(strcmp({out_header.chanlocs.labels},channel_lbl{klbl}))];
+end
 
 %data
 out_data=data(:,channel_idx,:,:,:,:);


### PR DESCRIPTION
In this way, channels are selected based on the label and not on the index in the data matrix. This solves the problem that appeared when a group of datasets had different number of channels (e.g. when a noisy channel was removed in some but not all datasets). In the previous version, the script would look in the indexes of the first dataset, which could match (or not) the indexes in the rest of the selected datasets.