### PR TITLE
Import epoched EEGLAB files with all their events

### DIFF
--- a/RLW/RLW_import_SET.m
+++ b/RLW/RLW_import_SET.m
@@ -72,8 +72,14 @@ else
         if isnumeric(event.code);
             event.code=num2str(event.code);
         end;
-        event.latency=(trg(eventpos).sample*out_header.xstep)+out_header.xstart;
-        event.epoch=1;
+        if(out_header.datasize(1)==1) %if it is continous data or just a single epoch
+            event.latency=(trg(eventpos).sample*out_header.xstep)+out_header.xstart;
+            event.epoch=1;
+        else %if it is an epoched dataset
+            event.epoch = floor(trg(eventpos).sample/out_header.datasize(6))+1;
+            event.latency=((trg(eventpos).sample*out_header.xstep)+out_header.xstart)-...
+                            (event.epoch-1)*out_header.xstep*out_header.datasize(6);
+        end
         out_header.events(eventpos)=event;
     end;
 end;


### PR DESCRIPTION
Before, only continous data had all events imported, while epoched datasets contained only the first one or two events. This was due to the way the event latency was computed.  The events ended up being banned in CLW_save.m (line 48)

Now it should be possible to import all events in both continous and epoched datasets.
